### PR TITLE
fix: Traverse branches of if/await blocks in preprocessor

### DIFF
--- a/src/lib/preprocessReact.ts
+++ b/src/lib/preprocessReact.ts
@@ -214,7 +214,20 @@ function replaceReactTags(
       }
     }
   }
+  // traverse children
   node.children?.forEach((child) => {
+    replaceReactTags(child, content, components);
+  });
+  // traverse else branch of IfBlock
+  node.else?.children?.forEach((child) => {
+    replaceReactTags(child, content, components);
+  });
+  // traverse then branch of AwaitBlock
+  node.then?.children?.forEach((child) => {
+    replaceReactTags(child, content, components);
+  });
+  // traverse catch branch of AwaitBlock
+  node.catch?.children?.forEach((child) => {
     replaceReactTags(child, content, components);
   });
   return components;


### PR DESCRIPTION
Currently the preprocessor does not traverse the children of the else/then/catch branches in if and await blocks - this fixes it in naive way.

P.s. Thanks for the great library! We're currently using it at Ourverse to move over to Svelte and it's been great.