### PR TITLE
fix: children with the same key warning

### DIFF
--- a/src/lib/internal/Bridge.ts
+++ b/src/lib/internal/Bridge.ts
@@ -38,7 +38,7 @@ const Bridge: React.FC<BridgeProps> = ({ createPortal, node }) => {
   }
   if (hooks.length >= 0) {
     children.push(
-      ...hooks.map(({ Hook, key }) => React.createElement(Hook, { key }))
+      ...hooks.map(({ Hook, key }) => React.createElement(Hook, { key: "hook" + key }))
     );
   }
   return createPortal(


### PR DESCRIPTION
We're getting a lot of "Encountered two children with the same key" warnings, which generally pollutes console logs...

It turns out Bridge and Hook components were being created with the same key as children of the same parent - this should fix that