### PR TITLE
Add support for arrays in payload.out to fix build errors

### DIFF
--- a/src/lib/sveltify.svelte.ts
+++ b/src/lib/sveltify.svelte.ts
@@ -243,7 +243,7 @@ function single<T extends React.FC | React.ComponentClass>(
  * (Mutates target and source objects)
  */
 function applyPortals(
-  $$payload: { out: string[] },
+  $$payload: { out: string | string[] },
   node: TreeNode,
   source: { html: string },
 ) {
@@ -255,7 +255,7 @@ function applyPortals(
 }
 
 function applyPortal(
-  $$payload: { out: string[] },
+  $$payload: { out: string | string[] },
   node: TreeNode,
   source: { html: string },
 ) {
@@ -281,13 +281,12 @@ function applyPortal(
     );
 
     source.html = portal.outerRemoved;
-    $$payload.out = [
-      inject(
-        portalTag("svelte", "portal", "target", node.key),
-        portal.innerHtml,
-        $$payload.out,
-      )
-    ];
+    const out = inject(
+      portalTag("svelte", "portal", "target", node.key),
+      portal.innerHtml,
+      $$payload.out,
+    );
+    $$payload.out = Array.isArray($$payload.out) ? [out] : out;
   } catch (err) {
     if (!node.parent) {
       throw err;


### PR DESCRIPTION
When using `svelte-preprocess-react` with Svelte >5.36.7 the build fails during prerendering.

https://github.com/sveltejs/svelte/pull/16428 which is part of [Svelte 5.36.8](https://github.com/sveltejs/svelte/releases/tag/svelte%405.36.8) causes the build to fail with the error:

```
[500] GET /
TypeError: html2.substring is not a function
```

Because of this the Svelte dependency in our project can no longer be upgraded.

This change adds support for arrays in functions handling `$$payload`. I don't know if this is the right way to address the underlying issue.